### PR TITLE
Require Ruby 2.0+ since gem is using keyword args

### DIFF
--- a/signal_lamp.gemspec
+++ b/signal_lamp.gemspec
@@ -19,6 +19,7 @@ END_DESCRIPTION
   spec.extra_rdoc_files = %w[README.md]
   spec.rdoc_options    << "--main" << "README.md"
   spec.require_paths    = %w[lib]
+  spec.required_ruby_version = ">= 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake",    "~> 10.3"


### PR DESCRIPTION
Encoding required Ruby version in the gemspec to improve feedback to the user.

(Using JRuby 1.7 means using no keyword arguments. I'm one of those users, noticing it too late.)
